### PR TITLE
Custom lazygit commands

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(chmod +x *)",
-      "Bash(python3 *)"
+      "Bash(python3 *)",
+      "Bash(git -C ~/dotfiles commit -m ' *)"
     ]
   }
 }

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,0 +1,51 @@
+gui:
+  skipDiscardChangeWarning: true
+
+customCommands:
+  - key: 'n'
+    description: 'New worktree (wt switch --create)'
+    context: 'worktrees'
+    loadingText: 'Creating worktree...'
+    prompts:
+      - type: 'menu'
+        title: 'Branch prefix'
+        key: 'Prefix'
+        options:
+          - name: 'feature/'
+            value: 'feature/'
+          - name: 'fix/'
+            value: 'fix/'
+          - name: 'none'
+            value: ''
+      - type: 'input'
+        title: 'Branch name'
+        key: 'BranchName'
+    command: >-
+      BRANCH="{{.Form.Prefix}}{{.Form.BranchName}}";
+      BASE=$(case $(git rev-parse --show-toplevel) in
+      (*latitude/data-llm) echo development;;
+      (*latitude/llm) echo latitude-v1;;
+      (*) echo main;; esac);
+      if (git show-ref --verify --quiet refs/heads/$BRANCH && wt switch $BRANCH ||
+      wt switch --create $BRANCH --base $BASE); then
+      NEW_PATH=$(git worktree list | grep -F "[$BRANCH]" | awk '{print $1}');
+      echo "$NEW_PATH" > ~/.nvim_cwd;
+      [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-expr "execute('cd $NEW_PATH')" 2>/dev/null;
+      [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-expr 'execute("bdelete!")' 2>/dev/null;
+      fi
+
+  - key: '<space>'
+    description: 'Switch to this worktree (nvim + shell)'
+    context: 'worktrees'
+    command: 'echo "{{.SelectedWorktree.Path}}" > ~/.nvim_cwd; [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-expr "execute(''cd {{.SelectedWorktree.Path}}'')" 2>/dev/null; [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-expr ''execute("bdelete!")'' 2>/dev/null'
+
+  - key: 'p'
+    description: 'Promote worktree (wt promote)'
+    context: 'worktrees'
+    command: >-
+      BRANCH=$(git branch --show-current);
+      PRIMARY=$(git worktree list | awk 'NR==1{print $1}');
+      echo "$PRIMARY" > ~/.nvim_cwd;
+      nohup sh -c "sleep 2 && wt remove --no-delete-branch --yes '$BRANCH' && git -C '$PRIMARY' checkout '$BRANCH'" >/tmp/wt_promote.log 2>&1 &;
+      [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-expr "execute('cd $PRIMARY')" 2>/dev/null;
+      [ -n "$NVIM" ] && nvim --server "$NVIM" --remote-send "q" 2>/dev/null

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -93,3 +93,16 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
 
 # bun completions
 [ -s "/Users/andres/.bun/_bun" ] && source "/Users/andres/.bun/_bun"
+
+# ------------------------------
+# cd to worktree path written by lazygit when nvim is stopped in background
+# ------------------------------
+function _nvim_cwd_precmd() {
+  if [[ -f ~/.nvim_cwd ]] && jobs | grep -q nvim; then
+    local new_cwd
+    new_cwd=$(< ~/.nvim_cwd)
+    rm -f ~/.nvim_cwd
+    [[ -d "$new_cwd" ]] && cd "$new_cwd"
+  fi
+}
+add-zsh-hook precmd _nvim_cwd_precmd


### PR DESCRIPTION
## What?

Lazygit custom commands for [worktrunk](https://worktrunk.dev) worktree management, wired up to nvim (via lazygit.nvim) and the shell.

## Lazygit commands (Worktrees panel)

### `n` — New worktree
Two prompts:
1. **Branch prefix** — menu: `feature/`, `fix/`, or none
2. **Branch name** — free text

Handles re-creating a worktree for an existing branch (skips `--create` if the branch already exists).

After the worktree is created:
- Writes the new path to `~/.nvim_cwd`
- cds nvim to the new worktree via `nvim --server $NVIM --remote-expr`
- Closes the lazygit floating window via `bdelete!`

### `<space>` — Switch to selected worktree
Same cd + close behaviour as `n`, but for an already-existing worktree selected in the list. Uses `{{.SelectedWorktree.Path}}`.

### `p` — Promote worktree
Runs `wt promote`: removes the current worktree and checks out its branch in the primary worktree.

## Shell auto-cd (`zsh/zshrc`)

A `precmd` hook reads `~/.nvim_cwd` and `cd`s the shell when nvim is stopped in the background (i.e. after `Ctrl+Z`). The file is removed after reading so it only fires once. The hook only activates when nvim appears as a stopped job, so it doesn't interfere with normal shell use.

## Symlink

`lazygit/config.yml` is tracked in dotfiles and symlinked to `~/Library/Application Support/lazygit/config.yml`.